### PR TITLE
Iterate through `aws\results` instead of `array`

### DIFF
--- a/src/SubscriptionRepository.php
+++ b/src/SubscriptionRepository.php
@@ -36,7 +36,7 @@ class SubscriptionRepository
         $responses = Utils::all($promises)->wait();
 
         return collect($responses)
-            ->flatmap(fn (array $result): array => $result['Items'])
+            ->flatmap(fn (\Aws\Result $result): array => $result['Items'])
             ->map(fn (array $item): string => $item['connectionId']['S'])
             ->unique();
     }


### PR DESCRIPTION
## Description

This PR prevents an error thrown due to the wrong argument type received, expected an `array` but receives an `AWS\Results` instance.

Error example:
```
Georgeboot\LaravelEchoApiGateway\SubscriptionRepository::Georgeboot\LaravelEchoApiGateway\{closure}(): 
Argument #1 ($result) must be of type array, Aws\Result given